### PR TITLE
[#7] Add missing robots.txt file to the asset file types

### DIFF
--- a/.travis/test-script.sh
+++ b/.travis/test-script.sh
@@ -118,3 +118,41 @@ if [ ! -L "$SITE_WEB/themes/travis-test-image.jpg" ]; then
 else
   echo "${MSG_OK} 'composer drupal:paranoia' command re-created the web directory with new symlinks"
 fi
+
+##
+# Create a "customfile.txt", configure the 'drupal-asset-files' extra key,
+# run the command 'composer drupal:paranoia' and check if the file has been symlinked.
+#
+echo "${MSG_INFO} Create a \"customfile.txt\" and configure the 'drupal-asset-files' extra key to check if the file has been symlinked."
+
+touch "$SITE_APP/customfile.txt"
+composer config extra.drupal-asset-files.should-be-simlinked customfile.txt
+
+# Rebuild web directory.
+composer drupal:paranoia || exit 1
+
+if [ ! -L "$SITE_WEB/customfile.txt" ]; then
+  echo "${MSG_ERROR} 'composer drupal:paranoia' command did not re-create the web directory with extra symlinks"
+  exit 1
+else
+  echo "${MSG_OK} 'composer drupal:paranoia' command re-created the web directory with extra symlinks"
+fi
+
+##
+# Create a "customfile.php", configure the 'drupal-asset-files' extra key,
+# run the command 'composer drupal:paranoia' and check if the file has not been symlinked.
+#
+echo "${MSG_INFO} Create a \"customfile.php\" and configure the 'drupal-asset-files' extra key to check if the file has not been symlinked."
+
+touch "$SITE_APP/customfile.php"
+composer config extra.drupal-asset-files.should-not-be-simlinked customfile.php
+
+# Rebuild web directory.
+composer drupal:paranoia || exit 1
+
+if [ -L "$SITE_WEB/customfile.php" ]; then
+  echo "${MSG_ERROR} 'composer drupal:paranoia' command re-created the web directory with WRONG extra symlinks"
+  exit 1
+else
+  echo "${MSG_OK} 'composer drupal:paranoia' command did not re-create the web directory with WRONG extra symlinks"
+fi

--- a/README.md
+++ b/README.md
@@ -47,6 +47,56 @@ composer require drupal-composer/drupal-paranoia:~1
 
 Done! Plugin and new docroot are now installed.
 
+## Optional Configuration
+
+### Modify the asset file types
+
+To extend the list of assets file types you can use the
+`drupal-asset-files` extra key:
+```json
+"extra": {
+    "drupal-asset-files": [
+        "somefile.txt",
+        "*.md"
+    ],
+    "..."
+}
+```
+
+If you need to modify it you can use the 
+`post-drupal-set-asset-file-types` event:
+```json
+"scripts": {
+    "post-drupal-set-asset-file-types": [
+        "DrupalProject\\composer\\ScriptHandler::setAssetFileTypes"
+    ],
+    "..."
+},
+```
+
+```php
+<?php
+
+/**
+ * @file
+ * Contains \DrupalProject\composer\ScriptHandler.
+ */
+
+namespace DrupalProject\composer;
+
+use DrupalComposer\DrupalParanoia\AssetFileTypesEvent;
+
+class ScriptHandler {
+
+  public static function setAssetFileTypes(AssetFileTypesEvent $event) {
+    $asset_file_types = $event->getAssetFileTypes();
+    // Do what you want with the asset file types.
+    $event->setAssetFileTypes($asset_file_types);
+  }
+
+}
+```
+
 ## Folder structure
 Your project now is basically structured on two folders.
 - __app__: Contains the files and folders of the full Drupal installation.

--- a/src/AssetFileTypesEvent.php
+++ b/src/AssetFileTypesEvent.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace DrupalComposer\DrupalParanoia;
+
+use Composer\Composer;
+use Composer\EventDispatcher\Event;
+use Composer\IO\IOInterface;
+
+/**
+ * Class AssetFileTypesEvent.
+ *
+ * @package DrupalComposer\DrupalParanoia
+ */
+class AssetFileTypesEvent extends Event {
+
+  /**
+   * This event occurs after the asset file types have been set.
+   *
+   * @var string
+   */
+  const POST_DRUPAL_SET_ASSET_FILE_TYPES = 'post-drupal-set-asset-file-types';
+
+  /**
+   * Composer object.
+   *
+   * @var \Composer\Composer
+   */
+  private $composer;
+
+  /**
+   * IO object.
+   *
+   * @var \Composer\IO\IOInterface
+   */
+  private $io;
+
+  /**
+   * Asset file types.
+   *
+   * @var array
+   */
+  private $assetFileTypes;
+
+  /**
+   * AssetFileTypesEvent constructor.
+   *
+   * @param array $assetFileTypes
+   *   The asset file types.
+   * @param \Composer\Composer $composer
+   *   The composer object.
+   * @param \Composer\IO\IOInterface $io
+   *   The IOInterface object.
+   * @param array $args
+   *   Arguments passed by the user
+   * @param array $flags
+   *   Optional flags to pass data not as argument.
+   */
+  public function __construct(array $assetFileTypes, Composer $composer, IOInterface $io, array $args = array(), array $flags = array()) {
+    parent::__construct(self::POST_DRUPAL_SET_ASSET_FILE_TYPES, $args, $flags);
+
+    $this->composer = $composer;
+    $this->io = $io;
+    $this->assetFileTypes = $assetFileTypes;
+  }
+
+  /**
+   * @return \Composer\Composer
+   */
+  public function getComposer() {
+    return $this->composer;
+  }
+
+  /**
+   * @return \Composer\IO\IOInterface
+   */
+  public function getIo() {
+    return $this->io;
+  }
+
+  /**
+   * @return array
+   */
+  public function getAssetFileTypes() {
+    return $this->assetFileTypes;
+  }
+
+  /**
+   * @param array $assetFileTypes
+   */
+  public function setAssetFileTypes(array $assetFileTypes) {
+    $this->assetFileTypes = $assetFileTypes;
+  }
+
+}


### PR DESCRIPTION
<!--- Provide a succinct summary of the issue in the title above -->
There is no symlink to the robots.txt in the web directory.

### Issue links
#7

### Description
<!--- Provide an overview of the change being made -->
As suggested in https://github.com/drupal-composer/drupal-paranoia/issues/7#issuecomment-402758009

* Provide the optional composer.json assets types config: `drupal-asset-files`
* Remove the default value from `$assetFileTypes` property
* Create a new method `setAssetFileTypes()` that will:
  * Set a default list of files copied from `$assetFileTypes` (include `robots.txt`)
  * Merge `drupal-asset-files` list to the list (if defined)
  * Trigger an event `post-drupal-set-asset-file-types` to allow other plugins alter the list of files
  * Set `$assetFileTypes` property value
* Call `setAssetFileTypes()` at `__construct()`
* Remove `.php` values from the list on `createAssetSymlinks()` method.
* Update `README` with the new optional config `drupal-asset-files`
* Update travis tests script `test-script.sh`.

I choose to remove `.php` values from the list on `createAssetSymlinks()` method and not `setAssetFileTypes()` because if in the last one we just use a simple `preg_match` on the list to remove them people could still trick it with something like `mycustomfile.*` and a file named `mycustomfile.php`.
