### PR TITLE
[#9] Add support for multisite

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -106,11 +106,6 @@ class Installer {
     $this->appDir = $extra['drupal-app-dir'];
     $this->webDir = $extra['drupal-web-dir'];
 
-    $this->publicFilesSymlinkTarget = $this->appDir . '/sites/default/files';
-    if (!empty($extra['drupal-web-dir-public-files'])) {
-      $this->publicFilesSymlinkTarget = $extra['drupal-web-dir-public-files'];
-    }
-
     $this->setAssetFileTypes();
   }
 
@@ -236,14 +231,16 @@ class Installer {
    */
   public function createPublicFilesSymlink() {
     $cfs = new ComposerFilesystem();
+    $finder = new Finder();
 
-    $symlinkTarget = $this->publicFilesSymlinkTarget;
-    if (!file_exists(realpath($symlinkTarget))) {
-      $symlinkTarget = $this->appDir . '/sites/default/files';
+    $finder->in($this->appDir . '/sites')
+      ->depth(0);
+
+    /** @var \Symfony\Component\Finder\SplFileInfo $directory */
+    foreach ($finder->directories() as $directory) {
+      $cfs->ensureDirectoryExists($this->webDir . '/sites/' . $directory->getFilename());
+      $cfs->relativeSymlink($directory->getRealPath() . '/files', realpath($this->webDir) . '/sites/' . $directory->getFilename() . '/files');
     }
-
-    $cfs->ensureDirectoryExists($this->webDir . '/sites/default');
-    $cfs->relativeSymlink(realpath($symlinkTarget), realpath($this->webDir) . '/sites/default/files');
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a succinct summary of the issue in the title above -->
Drupal Paranoia does not support multisite.

### Issue links
<!--- Provide links to related issues -->
#9 

### Description
<!--- Provide an overview of the change being made -->
In `Installer::createPublicFilesSymlink()` only `sites/default/files` was allowed. To support multisite I chose to stay simple for the moment: consider that every folder inside `sites` is a site and should have a `files` folder.

I removed the configuration `drupal-web-dir-public-files` since IMHO it did not seem to make sense to having it. Could you explain the purpose?


