### PR TITLE
Implement event 'drupal-paranoia-post-command-run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,48 @@ class ScriptHandler {
 }
 ```
 
+#### Plugin events
+This plugin fires the following named event during its execution process:
+
+- __drupal-paranoia-post-command-run__: Occurs after the command `drupal:paranoia` is executed.
+
+##### Example of event subscriber
+
+```php
+<?php
+
+namespace MyVendor;
+
+use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\IO\IOInterface;
+use Composer\Plugin\PluginInterface;
+use DrupalComposer\DrupalParanoia\PluginEvents as DrupalParanoiaPluginEvents;
+
+class MyClass implements PluginInterface, EventSubscriberInterface
+{
+    protected $composer;
+    protected $io;
+
+    public function activate(Composer $composer, IOInterface $io)
+    {
+        $this->composer = $composer;
+        $this->io = $io;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            DrupalParanoiaPluginEvents::POST_COMMAND_RUN => 'postDrupalParanoiaCommand',
+        );
+    }
+
+    public function postDrupalParanoiaCommand(CommandEvent $event) {
+        // Add your custom action.
+    }
+}
+```
+
 ## Folder structure
 Your project now is basically structured on two folders.
 - __app__: Contains the files and folders of the full Drupal installation.

--- a/src/DrupalParanoiaCommand.php
+++ b/src/DrupalParanoiaCommand.php
@@ -3,6 +3,7 @@
 namespace DrupalComposer\DrupalParanoia;
 
 use Composer\Command\BaseCommand;
+use Composer\Plugin\CommandEvent;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -30,6 +31,10 @@ class DrupalParanoiaCommand extends BaseCommand {
   protected function execute(InputInterface $input, OutputInterface $output) {
     $installer = new Installer($this->getComposer(), $this->getIO());
     $installer->install();
+
+    $composer = $this->getComposer();
+    $commandEvent = new CommandEvent(PluginEvents::POST_COMMAND_RUN, 'drupal:paranoia', $input, $output);
+    $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);
   }
 
 }

--- a/src/PluginEvents.php
+++ b/src/PluginEvents.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DrupalComposer\DrupalParanoia;
+
+/**
+ * The Plugin Events.
+ */
+class PluginEvents {
+  /**
+   * The POST_COMMAND_RUN event occurs after the command is executed.
+   *
+   * @var string
+   */
+  const POST_COMMAND_RUN = 'drupal-paranoia-post-command-run';
+
+}


### PR DESCRIPTION
### Description
Enhancement to provide an event to allow other plugins to execute their actions after the command `drupal:paranoia` is executed.
