### PR TITLE
Namespace composer config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ install:
   # https://github.com/drupal-composer/drupal-paranoia#configuration
   - cd "$SITE_ROOT"; mv "$SITE_ROOT/web" "$SITE_ROOT/app"
   - sed -e "s?web/?app/?g" --in-place "$SITE_ROOT/composer.json"
-  - cd "$SITE_ROOT"; composer config extra.drupal-app-dir app
-  - cd "$SITE_ROOT"; composer config extra.drupal-web-dir web
+  - cd "$SITE_ROOT"; composer config extra.drupal-paranoia.app-dir app
+  - cd "$SITE_ROOT"; composer config extra.drupal-paranoia.web-dir web
 
   # Require local drupal-paranoia project.
   - cd "$SITE_ROOT"; composer config repositories.local_drupal_paranoia path "$TRAVIS_BUILD_DIR"

--- a/.travis/test-script.sh
+++ b/.travis/test-script.sh
@@ -144,13 +144,13 @@ else
 fi
 
 ##
-# Create a "customfile.txt", configure the 'drupal-asset-files' extra key,
+# Create a "customfile.txt", configure the 'asset-files' extra key,
 # run the command 'composer drupal:paranoia' and check if the file has been symlinked.
 #
-echo "${MSG_INFO} Create a \"customfile.txt\" and configure the 'drupal-asset-files' extra key to check if the file has been symlinked."
+echo "${MSG_INFO} Create a \"customfile.txt\" and configure the 'asset-files' extra key to check if the file has been symlinked."
 
 touch "$SITE_APP/customfile.txt"
-composer config extra.drupal-asset-files.should-be-simlinked customfile.txt
+composer config extra.drupal-paranoia.asset-files.should-be-simlinked customfile.txt
 
 # Rebuild web directory.
 composer drupal:paranoia || exit 1
@@ -163,13 +163,13 @@ else
 fi
 
 ##
-# Create a "customfile.php", configure the 'drupal-asset-files' extra key,
+# Create a "customfile.php", configure the 'asset-files' extra key,
 # run the command 'composer drupal:paranoia' and check if the file has not been symlinked.
 #
-echo "${MSG_INFO} Create a \"customfile.php\" and configure the 'drupal-asset-files' extra key to check if the file has not been symlinked."
+echo "${MSG_INFO} Create a \"customfile.php\" and configure the 'asset-files' extra key to check if the file has not been symlinked."
 
 touch "$SITE_APP/customfile.php"
-composer config extra.drupal-asset-files.should-not-be-simlinked customfile.php
+composer config extra.drupal-paranoia.asset-files.should-not-be-simlinked customfile.php
 
 # Rebuild web directory.
 composer drupal:paranoia || exit 1

--- a/.travis/test-script.sh
+++ b/.travis/test-script.sh
@@ -150,7 +150,7 @@ fi
 echo "${MSG_INFO} Create a \"customfile.txt\" and configure the 'asset-files' extra key to check if the file has been symlinked."
 
 touch "$SITE_APP/customfile.txt"
-composer config extra.drupal-paranoia.asset-files.should-be-simlinked customfile.txt
+composer config extra.drupal-paranoia.asset-files token_list_files; sed -i -e "s/\"token_list_files\"/\[\"customfile.txt\"\]/" composer.json
 
 # Rebuild web directory.
 composer drupal:paranoia || exit 1
@@ -169,7 +169,7 @@ fi
 echo "${MSG_INFO} Create a \"customfile.php\" and configure the 'asset-files' extra key to check if the file has not been symlinked."
 
 touch "$SITE_APP/customfile.php"
-composer config extra.drupal-paranoia.asset-files.should-not-be-simlinked customfile.php
+composer config extra.drupal-paranoia.asset-files token_list_files; sed -i -e "s/\"token_list_files\"/\[\"customfile.php\"\]/" composer.json
 
 # Rebuild web directory.
 composer drupal:paranoia || exit 1

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ Update the `composer.json` of your root package with the following changes:
         "app/themes/contrib/{$name}": ["type:drupal-theme"],
         "drush/contrib/{$name}": ["type:drupal-drush"]
     },
-    "drupal-app-dir": "app",
-    "drupal-web-dir": "web",
+    "drupal-paranoia": {
+        "app-dir": "app",
+        "web-dir": "web"
+    },
     "..."
 }
 ```
@@ -48,18 +50,22 @@ composer require drupal-composer/drupal-paranoia:~1
 
 Done! The plugin and the new docroot are now installed.
 
-### Optional Configuration
+### Optional Configurations
 
 #### Modify the asset file types
 
-To extend the list of assets file types you can use the
-`drupal-asset-files` extra key:
+To extend the list of assets file types you can use the `asset-files` config:
 ```json
 "extra": {
-    "drupal-asset-files": [
-        "somefile.txt",
-        "*.md"
-    ],
+    "...",
+    "drupal-paranoia": {
+        "app-dir": "app",
+        "web-dir": "web",
+        "asset-files": [
+            "somefile.txt",
+            "*.md"
+        ]
+    },
     "..."
 }
 ```

--- a/src/DrupalParanoiaCommand.php
+++ b/src/DrupalParanoiaCommand.php
@@ -21,7 +21,7 @@ class DrupalParanoiaCommand extends BaseCommand {
     parent::configure();
     $this
       ->setName('drupal:paranoia')
-      ->setAliases(['drupal-paranoia'])
+      ->setAliases(array('drupal-paranoia'))
       ->setDescription('Execute the installation of the paranoia mode.');
   }
 


### PR DESCRIPTION
The plugin have configs where the users must set to their composer.json:

- `drupal-app-dir`
- `drupal-web-dir`
- `drupal-asset-files` (optional)

Example:
```
"extra": {
    "drupal-app-dir": "app",
    "drupal-web-dir": "web",
    "drupal-asset-files": [
        "somefile.txt",
             "*.md"
        ]
} 
```

To make the plugin config consistent with other drupal-composer projects (such as drupal-scaffold) and to better visualize/organize the configs, would be great to namespace it, like:
```
"extra": {
    "drupal-paranoia": {
        "app-dir": "app",
        "web-dir": "web",
        "asset-files": [
            "somefile.txt",
            "*.md"
        ]
    },
    "..."
}
```

### Backward compatibility
All the legacy configs will be compatible until we cut a stable version where the deprecated configs will be removed. 