### PR TITLE
Add new config 'excludes' to be able to exclude paths

### DIFF
--- a/.travis/test-script.sh
+++ b/.travis/test-script.sh
@@ -180,3 +180,20 @@ if [ -L "$SITE_WEB/customfile.php" ]; then
 else
   echo "${MSG_OK} 'composer drupal:paranoia' command did not re-create the web directory with WRONG extra symlinks"
 fi
+
+##
+# Test "excludes" config.
+# Run the command 'composer drupal:paranoia' and check if the excluded paths were not symlinked or stubbed.
+#
+echo "${MSG_INFO} Add paths to 'excludes' config and check if they have not been stubbed or symlinked."
+composer config extra.drupal-paranoia.excludes token_list_files; sed -i -e "s/\"token_list_files\"/\[\"core\/install.php\"\,\"core\/tests\"\]/" composer.json
+
+# Rebuild web directory.
+composer drupal:paranoia || exit 1
+
+if [ -f "$SITE_WEB/core/install.php" ] || [ -d "$SITE_WEB/core/tests" ]; then
+  echo "${MSG_ERROR} 'composer drupal:paranoia' command re-created the web directory with excluded files and folders"
+  exit 1
+else
+  echo "${MSG_OK} 'composer drupal:paranoia' command did not re-create the web directory with excluded files and folders"
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Releases
 
+### 1.0.0-beta4, 2019-01-24
+- [PR#13] Added new config 'excludes' to be able to exclude paths to be symlinked or stubbed in web folder.
+- Performance enhancement: Added sites public files path to exclude list when searching for asset files. 
+
 ### 1.0.0-beta3, 2019-01-23
 - [PR#12] Namespaced composer config. See: https://github.com/drupal-composer/drupal-paranoia/pull/12.
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,28 @@ By the purpose of this plugin, the following files types are __not allowed__ and
 *.theme
 ```
 
+### Exclude paths
+With the drupal-paranoia option excludes, you can provide paths that should not be symlinked or stubbed to `/web` folder. The plugin provides no excludes by default.
+
+```json
+"extra": {
+    "drupal-paranoia": {
+        "app-dir": "app",
+        "web-dir": "web",
+        "excludes": [
+            "core/install.php",
+            "sites/simpletest"
+        ]
+    },
+    "..."
+}
+```
+
+__NOTE:__ Consider to exclude `/install.php` from your site. There are security concerns when this URL is publicly available, it can be used to create a list of contributed modules existing on the site.
+You can exclude it via plugin as described above or via `.htaccess` rules. 
+- [DO#2840973: Install system should not produce PHP errors](https://www.drupal.org/node/2840973)    
+- https://www.drupalxray.com
+
 ### Web server docroot
 Change the document root config of your web server to point to `/web` folder.
 
@@ -181,7 +203,7 @@ class MyClass implements PluginInterface, EventSubscriberInterface
 ```
 
 ## Local development
-Every time you install or update a Drupal package via Composer, the `/web` folder will recreated.
+Every time you install or update a Drupal package via Composer, the `/web` folder will be recreated.
 
 ```
 composer require drupal/devel:~1.0

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -75,6 +75,13 @@ class Installer {
   public $webDir;
 
   /**
+   * List of paths that should not be symlinked or stubbed.
+   *
+   * @var array
+   */
+  public $excludes;
+
+  /**
    * Installer constructor.
    *
    * @param \Composer\Composer $composer
@@ -86,20 +93,22 @@ class Installer {
     $this->composer = $composer;
     $this->io = $io;
 
-    $app_dir = $this->getConfig('app-dir');
-    if (!$app_dir) {
+    $appDir = $this->getConfig('app-dir');
+    if (!$appDir) {
       throw new \RuntimeException('Please configure app-dir in your composer.json');
     }
 
-    $web_dir = $this->getConfig('web-dir');
-    if (!$web_dir) {
+    $webDir = $this->getConfig('web-dir');
+    if (!$webDir) {
       throw new \RuntimeException('Please configure web-dir in your composer.json');
     }
 
-    $this->appDir = $app_dir;
-    $this->webDir = $web_dir;
+    $this->appDir = $appDir;
+    $this->webDir = $webDir;
 
     $this->setAssetFileTypes();
+
+    $this->excludes = $this->getConfig('excludes', array());
   }
 
   /**
@@ -107,32 +116,51 @@ class Installer {
    *
    * @param string $name
    *   The config name.
+   * @param mixed $default
+   *   The default value to return if the config does not exist.
    *
    * @return mixed
    *   The config value.
    */
-  public function getConfig($name) {
+  public function getConfig($name, $default = NULL) {
     $extra = $this->composer->getPackage()->getExtra();
 
     // TODO: Backward compatibility for old configs. Remove on stable version.
-    $legacy_configs = array(
+    $legacyConfigs = array(
       'drupal-app-dir',
       'drupal-web-dir',
       'drupal-asset-files',
     );
-    if (in_array("drupal-$name", $legacy_configs) && isset($extra["drupal-$name"])) {
+    if (in_array("drupal-$name", $legacyConfigs) && isset($extra["drupal-$name"])) {
       return $extra["drupal-$name"];
     }
 
     if (!isset($extra['drupal-paranoia'])) {
-      return NULL;
+      return $default;
     }
 
     if (isset($extra['drupal-paranoia'][$name])) {
       return $extra['drupal-paranoia'][$name];
     }
 
-    return NULL;
+    return $default;
+  }
+
+  /**
+   * Checks whether a path exists in the excludes list.
+   *
+   * @param string $path
+   *   The path.
+   *
+   * @return bool
+   *   Returns TRUE if the path is listed, FALSE otherwise.
+   */
+  public function isExcludedPath($path) {
+    if (!$this->excludes) {
+      return FALSE;
+    }
+
+    return in_array($path, $this->excludes);
   }
 
   /**
@@ -163,8 +191,8 @@ class Installer {
       return FALSE;
     }
 
-    $package_type = $package->getType();
-    if (!$package_type) {
+    $packageType = $package->getType();
+    if (!$packageType) {
       return FALSE;
     }
 
@@ -181,7 +209,7 @@ class Installer {
      *
      * @TODO: Add support for custom package types: 'oomphinc/composer-installers-extender' and 'davidbarratt/custom-installer'.
      */
-    if ((bool) preg_match("/(drupal)?-(core|module|theme|library|profile|drush|custom-module|custom-theme)/", $package_type)) {
+    if ((bool) preg_match("/(drupal)?-(core|module|theme|library|profile|drush|custom-module|custom-theme)/", $packageType)) {
       return TRUE;
     }
 
@@ -253,19 +281,42 @@ class Installer {
   }
 
   /**
+   * Returns a list containing the sites public files path.
+   *
+   * @return array
+   *   The path list.
+   */
+  public function getSitesPublicFilesPath() {
+    $finder = new Finder();
+    $finder->in($this->appDir . '/sites')
+      ->depth(0);
+
+    $directories = array();
+
+    /** @var \Symfony\Component\Finder\SplFileInfo $directory */
+    foreach ($finder->directories() as $directory) {
+      $publicFilesPath = 'sites/' . $directory->getFilename() . '/files';
+
+      if (!is_dir($this->appDir . '/' . $publicFilesPath)) {
+        continue;
+      }
+
+      $directories[] = $publicFilesPath;
+    }
+
+    return $directories;
+  }
+
+  /**
    * Symlink the public files folder.
    */
   public function createPublicFilesSymlink() {
     $cfs = new ComposerFilesystem();
-    $finder = new Finder();
+    $publicFilesPaths = $this->getSitesPublicFilesPath();
 
-    $finder->in($this->appDir . '/sites')
-      ->depth(0);
-
-    /** @var \Symfony\Component\Finder\SplFileInfo $directory */
-    foreach ($finder->directories() as $directory) {
-      $cfs->ensureDirectoryExists($this->webDir . '/sites/' . $directory->getFilename());
-      $cfs->relativeSymlink($directory->getRealPath() . '/files', realpath($this->webDir) . '/sites/' . $directory->getFilename() . '/files');
+    foreach ($publicFilesPaths as $path) {
+      $cfs->ensureDirectoryExists($this->webDir . '/' . dirname($path));
+      $cfs->relativeSymlink(realpath($this->appDir) . '/' . $path, realpath($this->webDir) . '/' . $path);
     }
   }
 
@@ -277,10 +328,12 @@ class Installer {
 
     $finder->ignoreDotFiles(FALSE)->in($this->appDir);
 
+    // Add asset files types to the search.
     foreach ($this->assetFileTypes as $name) {
       $finder->name($name);
     }
-    $finder->exclude('sites/default/files');
+
+    // Default extensions to exclude from the search.
     $finder->notName('*.inc');
     $finder->notName('*.install');
     $finder->notName('*.module');
@@ -288,6 +341,23 @@ class Installer {
     $finder->notName('*.php');
     $finder->notName('*.profile');
     $finder->notName('*.theme');
+
+    // Ignores excluded paths.
+    foreach ($this->excludes as $excludedPath) {
+      // If is a file.
+      if (isset(pathinfo($excludedPath)['extension'])) {
+        $finder->notName($excludedPath);
+        continue;
+      }
+
+      // Is a folder.
+      $finder->exclude($excludedPath);
+    }
+
+    // Ignores sites public files path.
+    foreach ($this->getSitesPublicFilesPath() as $publicFilesPath) {
+      $finder->exclude($publicFilesPath);
+    }
 
     $cfs = new ComposerFilesystem();
 
@@ -304,6 +374,10 @@ class Installer {
    *   The PHP file from the app directory.
    */
   public function createStubPhpFile($path) {
+    if ($this->isExcludedPath($path)) {
+      return;
+    }
+
     $appDir = realpath($this->appDir);
     $webDir = realpath($this->webDir);
 
@@ -348,9 +422,9 @@ EOF;
     );
 
     // Allow people to extend the list from a composer extra key.
-    $extra_asset_files = $this->getConfig('asset-files');
-    if ($extra_asset_files) {
-      $this->assetFileTypes = array_merge($this->assetFileTypes, $extra_asset_files);
+    $extraAssetFiles = $this->getConfig('asset-files');
+    if ($extraAssetFiles) {
+      $this->assetFileTypes = array_merge($this->assetFileTypes, $extraAssetFiles);
     }
 
     // Allow other plugins to alter the list of files.


### PR DESCRIPTION
Would be worth to have a new config `excludes` to list files to not be symlinked or stubbed in the web folder. Currently you have control over the asset file types list, you can include or alter the list, but you can't exclude a file or folder.

```json
"extra": {
    "drupal-paranoia": {
        "app-dir": "app",
        "web-dir": "web",
        "excludes": [
            "core/install.php",
            "sites/simpletest"
        ]
    },
    "..."
}
```

In this example, `install.php` and `sites/simpletest` will not be symlinked to web folder, it means that will not be available over the internet. 

As mentioned in the README:
```
Consider to exclude `/install.php` from your site. There are security concerns when this URL is publicly available, it can be used to create a list of contributed modules existing on the site.
You can exclude it via plugin as described above or via `.htaccess` rules. 
- [DO#2840973: Install system should not produce PHP errors](https://www.drupal.org/node/2840973)    
- https://www.drupalxray.com
```
