### PR TITLE
Add PHP code sniffer step on Travis test. Test PHP 7.2 and 7.3.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ sudo: false
 
 php:
   - 7.1
+  - 7.2
+  - 7.3
 
 matrix:
   fast_finish: true
@@ -58,4 +60,4 @@ script:
   - $TRAVIS_BUILD_DIR/.travis/test-script.sh
 
   # Sniff code standards.
-  - phpcs --standard=Drupal --ignore=*.md,*.txt --warning-severity=0 -d date.timezone=UTC .
+  - phpcs --standard=Drupal --ignore=*.md,*.txt,.travis/* --warning-severity=0 -d date.timezone=UTC .

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
 env:
   global:
     # Set the composer vendor Path.
-    - COMPOSER_VENDOR_PATH="$HOME/.composer/vendor"
+    - COMPOSER_VENDOR_PATH="$HOME/.config/composer/vendor"
 
     # Add executables into PATH.
     - PATH="$PATH:$COMPOSER_VENDOR_PATH/bin"
@@ -35,9 +35,9 @@ before_install:
   - composer global require hirak/prestissimo --no-interaction
 
   #  Install PHP Code Sniffer and Drupal Coding standards.
-  #- composer global require drupal/coder --prefer-dist -vvv || exit 1
-  #- phpcs --config-set installed_paths "$COMPOSER_VENDOR_PATH/drupal/coder/coder_sniffer"
-  #- phpcs --config-set ignore_warnings_on_exit 1
+  - composer global require drupal/coder --prefer-dist -vvv || exit 1
+  - phpcs --config-set installed_paths "$COMPOSER_VENDOR_PATH/drupal/coder/coder_sniffer"
+  - phpcs --config-set ignore_warnings_on_exit 1
 
 install:
   # Create Drupal project.
@@ -58,4 +58,4 @@ script:
   - $TRAVIS_BUILD_DIR/.travis/test-script.sh
 
   # Sniff code standards.
-  #- phpcs --standard=Drupal --ignore=*.md,*.txt --warning-severity=0 -d date.timezone=UTC .
+  - phpcs --standard=Drupal --ignore=*.md,*.txt --warning-severity=0 -d date.timezone=UTC .


### PR DESCRIPTION
Simple PR is to update `.travis.yml` to sniff the code for Drupal standards violations and test the code against PHP 7.2 and 7.3 (7.1 is already being tested).