### PR TITLE
Avoid error map file not found

### DIFF
--- a/src/Installer.php
+++ b/src/Installer.php
@@ -413,6 +413,7 @@ EOF;
       '*.jpeg',
       '*.jpg',
       '*.js',
+      '*.map',
       '*.otf',
       '*.png',
       '*.svg',


### PR DESCRIPTION
<!--- Provide a succinct summary of the issue in the title above -->

### Description
<!--- Provide an overview of the change being made -->

`.map` files are not listed as allowed assets but exists in Drupal Core see https://www.drupal.org/project/drupal/issues/2400675.

To avoid 404 errors on every loaded page `.map` files should be allowed.