### PR TITLE
Fix Travis memory limit issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: php
 
 ## Run on container environment
-sudo: true
+sudo: false
 
 php:
   - 7.1
@@ -24,6 +24,7 @@ env:
 
     - SITE_NAME="mysite"
     - SITE_ROOT="$TRAVIS_BUILD_DIR/../$SITE_NAME"
+    - COMPOSER_MEMORY_LIMIT=-1
 
 before_install:
   # Disable xdebug.

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: php
 
 ## Run on container environment
-sudo: false
+sudo: true
 
 php:
   - 7.1


### PR DESCRIPTION
Travis is throwing 

```
PHP Fatal error:  Allowed memory size of 1610612736 bytes exhausted (tried to allocate 67108864 bytes) in phar:///home/travis/.phpenv/versions/7.1.27/bin/composer/src/Composer/DependencyResolver/Solver.php on line 223
```