### PR TITLE
Support composer 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
 
 install:
   # Create Drupal project.
-  - composer create-project drupal-composer/drupal-project:8.x-dev --stability dev --no-interaction --no-dev --prefer-dist -vvv "$SITE_ROOT" || exit 1
+  - composer create-project drupal-composer/drupal-project:9.x-dev --stability dev --no-interaction --no-dev --prefer-dist -vvv "$SITE_ROOT" || exit 1
 
   # https://github.com/drupal-composer/drupal-paranoia#configuration
   - cd "$SITE_ROOT"; mv "$SITE_ROOT/web" "$SITE_ROOT/app"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ language: php
 sudo: false
 
 php:
-  - 7.1
-  - 7.2
   - 7.3
+  - 7.4
 
 matrix:
   fast_finish: true
@@ -25,17 +24,17 @@ env:
     - SITE_NAME="mysite"
     - SITE_ROOT="$TRAVIS_BUILD_DIR/../$SITE_NAME"
     - COMPOSER_MEMORY_LIMIT=-1
+  matrix:
+    - COMPOSER_CHANNEL=1
+    - COMPOSER_CHANNEL=2
 
 before_install:
   # Disable xdebug.
   - phpenv config-rm xdebug.ini
 
   # Update Composer.
-  - composer self-update --stable
+  - composer self-update "--${COMPOSER_CHANNEL}"
   - composer clear-cache
-
-  # Install composer parallel install plugin.
-  - composer global require hirak/prestissimo --no-interaction
 
   #  Install PHP Code Sniffer and Drupal Coding standards.
   - composer global require drupal/coder --prefer-dist -vvv || exit 1

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "GPL-2.0-or-later",
   "require": {
       "php": ">=5.4.5",
-      "composer-plugin-api": "^1.1"
+      "composer-plugin-api": "^1.1 || ^2"
   },
   "autoload": {
       "psr-4": {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -34,6 +34,16 @@ class Plugin implements PluginInterface, EventSubscriberInterface, Capable {
   /**
    * {@inheritdoc}
    */
+  public function deactivate(Composer $composer, IOInterface $io) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function uninstall(Composer $composer, IOInterface $io) {}
+
+  /**
+   * {@inheritdoc}
+   */
   public function getCapabilities() {
     return array(
       'Composer\Plugin\Capability\CommandProvider' => 'DrupalComposer\DrupalParanoia\CommandProvider',


### PR DESCRIPTION
### Issue links

#21 

### Description

See https://getcomposer.org/upgrade/UPGRADE-2.0.md

The only things that interest us if I read correctly is:

> PluginInterface added a deactivate (so plugin can stop whatever it is doing) and an uninstall (so the plugin can remove any files it created or do general cleanup) method.

I chose to do nothing during those new phases. Maybe we could delete the created `web-dir`? 🤷‍♂️ 