### PR TITLE
Add return code to DrupalParanoiaCommand

### DIFF
--- a/src/DrupalParanoiaCommand.php
+++ b/src/DrupalParanoiaCommand.php
@@ -35,6 +35,8 @@ class DrupalParanoiaCommand extends BaseCommand {
     $composer = $this->getComposer();
     $commandEvent = new CommandEvent(PluginEvents::POST_COMMAND_RUN, 'drupal:paranoia', $input, $output);
     $composer->getEventDispatcher()->dispatch($commandEvent->getName(), $commandEvent);
+
+    return 0;
   }
 
 }


### PR DESCRIPTION
### Description

This is just an improvement since every command should have a return code.

I've run into a problem while using Drupal Paranoia and Composer 2 with PlatformSh.
Composer 2 has been dowloaded and installed using Composer 1. This led to dependencies not having the correct version usually defined by `composer.lock`. I ended up with `symfony/console:5.3.10`, and it's `Command::execute()` signature does not match the one in `DrupalParanoiaCommand::execute()`.

I have solved the issue with PlatformSh, but I think having a return code is more consistent any other UNIX command, and also a return code 0 is equivalent to what it's done right now.